### PR TITLE
add atom feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ twitter:
 
 # Plugins
 plugins:
+  - jekyll-feed
   - jekyll-paginate
   - liquid_pluralize
 


### PR DESCRIPTION
I lifted this from [github's instruction](https://help.github.com/articles/atom-rss-feeds-for-github-pages/).